### PR TITLE
added citation to clarify what has come from IPython Cookbook

### DIFF
--- a/notes-aaron-full-2017-03-03.ipynb
+++ b/notes-aaron-full-2017-03-03.ipynb
@@ -2226,6 +2226,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This series of examples was also taken from the [IPython Cookbook](http://nbviewer.jupyter.org/github/ipython-books/cookbook-code/blob/master/notebooks/chapter05_hpc/05_ray_1.ipynb) (see Section 5). It was included here so that the output of the code could also be included (since the output is not rendered in the Cookbook). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Pure Python"
    ]
   },


### PR DESCRIPTION
It seemed unclear to me where the ray tracing example came from so I added an explicit link to the IPython Cookbook as reference. 